### PR TITLE
add continueOnError in settings

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -40,6 +40,7 @@ module.exports =
 			secret: process.env['AWS_SECRET_ACCESS_KEY']
 		stores:
 			doc_history: process.env['AWS_BUCKET']
+		continueOnError: process.env['TRACK_CHANGES_CONTINUE_ON_ERROR'] or false
 			
 	path:
 		dumpFolder:   Path.join(TMP_DIR, "dumpFolder")


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Fix for `Tried to apply raw op at version X to last compressed update with version Y` errors.

This is handled by the existing continueOnError setting, which we used to have enabled but lost in the migration.  This PR adds the setting to the configuration file.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/google-ops/pull/562

### Review

NA

#### Potential Impact

Setting only

#### Manual Testing Performed

- [X] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ] Need to set env var `TRACK_CHANGES_CONTINUE_ON_ERROR` as `true` in deployment (see https://github.com/overleaf/google-ops/pull/562)

#### Metrics and Monitoring

Sentry for "inconsistent doc versions" error

#### Who Needs to Know?

@henryoswald @jdleesmiller 