### PR TITLE
fix performance of update removal

### DIFF
--- a/app/coffee/RedisManager.coffee
+++ b/app/coffee/RedisManager.coffee
@@ -21,7 +21,7 @@ module.exports = RedisManager =
 		multi = rclient.multi()
 		# Delete all the updates which have been applied (exact match)
 		for update in docUpdates or []
-			multi.lrem Keys.uncompressedHistoryOps({doc_id}), 0, update
+			multi.lrem Keys.uncompressedHistoryOps({doc_id}), 1, update
 		multi.exec (error, results) ->
 			return callback(error) if error?
 			# It's ok to delete the doc_id from the set here. Even though the list

--- a/test/unit/coffee/RedisManager/RedisManagerTests.coffee
+++ b/test/unit/coffee/RedisManager/RedisManagerTests.coffee
@@ -56,12 +56,12 @@ describe "RedisManager", ->
 
 			it "should delete the first update from redis", ->
 				@rclient.lrem
-					.calledWith("UncompressedHistoryOps:#{@doc_id}", 0, @jsonUpdates[0])
+					.calledWith("UncompressedHistoryOps:#{@doc_id}", 1, @jsonUpdates[0])
 					.should.equal true
 
 			it "should delete the second update from redis", ->
 				@rclient.lrem
-					.calledWith("UncompressedHistoryOps:#{@doc_id}", 0, @jsonUpdates[1])
+					.calledWith("UncompressedHistoryOps:#{@doc_id}", 1, @jsonUpdates[1])
 					.should.equal true
 
 			it "should delete the doc from the set of docs with history ops", ->


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Fix performance of removal of updates from queues with LREM as in https://github.com/overleaf/project-history/pull/287

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/project-history/issues/152

https://github.com/overleaf/issues/issues/2359

### Review

Small change, as previously mentioned by JLM in https://github.com/overleaf/project-history/pull/287#issuecomment-498371250 it could lead to different behaviour with duplicate entries in the queue (a situation which should not occur in theory).  So far this has not  caused any noticeable problems in project history.


#### Potential Impact

Low

#### Manual Testing Performed

- [X] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

We don't have metrics for track changes - we should add some basic ones.

#### Who Needs to Know?

@henryoswald  @jdleesmiller 