### PR TITLE
[misc] update the build scripts to 1.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.4
+# Version: 1.3.5
 
-FROM node:10.19.0 as app
+FROM node:10.19.0 as base
 
 WORKDIR /app
+
+FROM base as app
 
 #wildcard as some files may not be in all repos
 COPY package*.json npm-shrink*.json /app/
@@ -17,11 +19,9 @@ COPY . /app
 
 RUN npm run compile:all
 
-FROM node:10.19.0
+FROM base
 
 COPY --from=app /app /app
-
-WORKDIR /app
 USER node
 
 CMD ["node", "--expose-gc", "app.js"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.4
+# Version: 1.3.5
 
 BUILD_NUMBER ?= local
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -7,4 +7,4 @@ track-changes
 --dependencies=mongo,redis,s3
 --docker-repos=gcr.io/overleaf-ops
 --env-pass-through=
---script-version=1.3.4
+--script-version=1.3.5

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,9 +1,9 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.4
+# Version: 1.3.5
 
-version: "2.1"
+version: "2.3"
 
 services:
   test_unit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 # This file was auto-generated, do not edit it directly.
 # Instead run bin/update_build_scripts from
 # https://github.com/sharelatex/sharelatex-dev-environment
-# Version: 1.3.4
+# Version: 1.3.5
 
-version: "2.1"
+version: "2.3"
 
 services:
   test_unit:
@@ -28,7 +28,7 @@ services:
       MONGO_HOST: mongo
       POSTGRES_HOST: postgres
       AWS_S3_ENDPOINT: http://s3:9090
-      AWS_S3_PATH_STYLE: "true"
+      AWS_S3_PATH_STYLE: 'true'
       AWS_ACCESS_KEY_ID: fake
       AWS_SECRET_ACCESS_KEY: fake
       MOCHA_GREP: ${MOCHA_GREP}


### PR DESCRIPTION
### Description

Update the build scripts for https://github.com/overleaf/dev-environment/pull/294

This adds a new `base` stage for the docker image.

#### Related Issues / PRs

https://github.com/overleaf/dev-environment/pull/294

### Review

- `language=es`

  The eslint rules changed in the build-scripts, which required some formatting
   changes. These were automatically applied by `prettier-eslint --write`.

- `spelling`

  An additional tweak was required to cleanup a pending task for the unit-tests.

- `filestore`,  `spelling` and `third-party-datastore`

  See https://github.com/overleaf/dev-environment/pull/294#issuecomment-584777526
   for details on the added `data-dir` parameter.

#### Potential Impact

Low.

We will notice any complications in regards to starting the services in staging.