### PR TITLE
Pinned adobe/s3mock docker image

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -52,7 +52,7 @@ services:
   mongo:
     image: mongo:3.6
   s3:
-    image: adobe/s3mock
+    image: adobe/s3mock:2.1.20
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files,bucket
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     image: mongo:3.6
 
   s3:
-    image: adobe/s3mock
+    image: adobe/s3mock:2.1.20
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files,bucket
     healthcheck:


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Fixes the problem of CI build being broken since June 11th 2020. A [newer image of `adobe/s3mock:2.1.21`](https://hub.docker.com/layers/adobe/s3mock/2.1.21/images/sha256-1bf8492f1e8d44297ed3b599713dab83de4d41beeff406cc21b636f808db8d36?context=explore) was pushed that day, causing the following error in `Archiving updates` acceptance tests:

```
One or more of the specified parts could not be found. The part might not have been uploaded, or the specified entity tag might not have matched the part's entity tag
```

Pinning the version, effectively rolling back to `2.1.20` fixes the build.

The only change introduced in `adobe/s3mock` is https://github.com/adobe/S3Mock/pull/224

Further investigation is required to understand the root cause, since `filestore` and `templates` services are using that image (so far without problems).


### Review

#### Potential Impact

Affects acceptance tests only

