### PR TITLE
Removed pinned version of adobe/s3mock docker image

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -52,7 +52,7 @@ services:
   mongo:
     image: mongo:3.6
   s3:
-    image: adobe/s3mock:2.1.20
+    image: adobe/s3mock
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files,bucket
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     image: mongo:3.6
 
   s3:
-    image: adobe/s3mock:2.1.20
+    image: adobe/s3mock
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files,bucket
     healthcheck:


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

The version of `adobe/s3mock` was pinned in https://github.com/overleaf/track-changes/pull/85 due to problems after `2.1.21` release.

The problem has been identified as a bug and fixed in `2.1.22` (see https://github.com/adobe/S3Mock/issues/223), so we're going back to the unpinned version.


### Review



#### Potential Impact

Tests only