### PR TITLE
[PackWorker] fixes for the native mongo driver

### DIFF
--- a/app/js/PackWorker.js
+++ b/app/js/PackWorker.js
@@ -15,10 +15,11 @@
  */
 let LIMIT, pending
 let project_id, doc_id
+const { callbackify } = require('util')
 const Settings = require('settings-sharelatex')
 const async = require('async')
 const _ = require('underscore')
-const { db, ObjectId, waitForDb } = require('./mongodb')
+const { db, ObjectId, waitForDb, closeDb } = require('./mongodb')
 const fs = require('fs')
 const Metrics = require('metrics-sharelatex')
 Metrics.initialize('track-changes')
@@ -84,7 +85,7 @@ const finish = function () {
     clearTimeout(shutDownTimer)
   }
   logger.log('closing db')
-  return db.close(function () {
+  callbackify(closeDb)(function () {
     logger.log('closing LockManager Redis Connection')
     return LockManager.close(function () {
       logger.log(

--- a/app/js/mongodb.js
+++ b/app/js/mongodb.js
@@ -23,8 +23,20 @@ async function setupDb() {
   db.projectHistoryMetaData = internalDb.collection('projectHistoryMetaData')
 }
 
+async function closeDb() {
+  let client
+  try {
+    client = await clientPromise
+  } catch (e) {
+    // there is nothing to close
+    return
+  }
+  return client.close()
+}
+
 module.exports = {
   db,
   ObjectId,
+  closeDb,
   waitForDb
 }


### PR DESCRIPTION
### Description

Followup for https://github.com/overleaf/track-changes/pull/94

The PackWorker is like a script, but it lives in `app/js` and hence was not treated separately in regards to db handling. This PR is adding the missing `waitForDb` call and also adjusts the cleanup process. 

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2907
https://github.com/overleaf/track-changes/pull/94

#### Potential Impact

High. Without the PackWorker the mongodb fills-up.

#### Manual Testing Performed

- start the service in the dev-env
- `$ curl -X POST 127.0.0.1:3015/pack`
- see reasonable output (previously the PackWorker crashed)
- `ready to exit from pack archive worker`
