### PR TITLE
[misc] bump @overleaf/redis-wrapper to version 2.0.0

### DIFF
--- a/app/js/LockManager.js
+++ b/app/js/LockManager.js
@@ -11,7 +11,7 @@
  */
 let LockManager
 const Settings = require('settings-sharelatex')
-const redis = require('redis-sharelatex')
+const redis = require('@overleaf/redis-wrapper')
 const rclient = redis.createClient(Settings.redis.lock)
 const os = require('os')
 const crypto = require('crypto')

--- a/app/js/RedisManager.js
+++ b/app/js/RedisManager.js
@@ -14,7 +14,7 @@
  */
 let RedisManager
 const Settings = require('settings-sharelatex')
-const redis = require('redis-sharelatex')
+const redis = require('@overleaf/redis-wrapper')
 const rclient = redis.createClient(Settings.redis.history)
 const Keys = Settings.redis.history.key_schema
 const async = require('async')

--- a/package-lock.json
+++ b/package-lock.json
@@ -906,9 +906,17 @@
       }
     },
     "@overleaf/o-error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@overleaf/o-error/-/o-error-3.0.0.tgz",
-      "integrity": "sha512-LsM2s6Iy9G97ktPo0ys4VxtI/m3ahc1ZHwjo5XnhXtjeIkkkVAehsrcRRoV/yWepPjymB0oZonhcfojpjYR/tg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@overleaf/o-error/-/o-error-3.1.0.tgz",
+      "integrity": "sha512-TWJ80ozJ1LeugGTJyGQSPEuTkZ9LqZD7/ndLE6azKa03SU/mKV/FINcfk8atpVil8iv1hHQwzYZc35klplpMpQ=="
+    },
+    "@overleaf/redis-wrapper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@overleaf/redis-wrapper/-/redis-wrapper-2.0.0.tgz",
+      "integrity": "sha512-lREuhDPNgmKyOmL1g6onfRzDLWOG/POsE4Vd7ZzLnKDYt9SbOIujtx3CxI2qtQAKBYHf/hfyrbtyX3Ib2yTvYA==",
+      "requires": {
+        "ioredis": "~4.17.3"
+      }
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3924,12 +3932,12 @@
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -4253,11 +4261,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
-    },
-    "mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg=="
     },
     "mocha": {
       "version": "7.1.1",
@@ -5613,11 +5616,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
-    "q": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/q/-/q-0.9.2.tgz",
-      "integrity": "sha512-ZOxMuWPMJnsUdYhuQ9glpZwKhB4cm8ubYFy1nNCY8TkSAuZun5fd8jCDTlf2ykWnK8x9HGn1stNtLeG179DebQ=="
-    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -5748,57 +5746,14 @@
     "redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
     },
     "redis-parser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
       "requires": {
         "redis-errors": "^1.0.0"
-      }
-    },
-    "redis-sentinel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/redis-sentinel/-/redis-sentinel-0.1.1.tgz",
-      "integrity": "sha512-cKtLSUzDsKmsB50J1eIV/SH11DSMiHgsm/gDPRCU5lXz5OyTSuLKWg9oc8d5n74kZwtAyRkfJP0x8vYXvlPjFQ==",
-      "requires": {
-        "q": "0.9.2",
-        "redis": "0.11.x"
-      },
-      "dependencies": {
-        "redis": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-0.11.0.tgz",
-          "integrity": "sha512-wkgzIZ9HuxJ6Sul1IW/6FG13Ecv6q8kmdHb5xo09Hu6bgWzz5qsnM06SVMpDxFNbyApaRjy8CwnmVaRMMhAMWg=="
-        }
-      }
-    },
-    "redis-sharelatex": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/redis-sharelatex/-/redis-sharelatex-1.0.13.tgz",
-      "integrity": "sha512-sAQNofqfcMlIxzxNJF1qUspJKDM1VuuIOrGZQX9nb5JtcJ5cusa5sc+Oyb51eymPV5mZGWT3u07tKtv4jdXVIg==",
-      "requires": {
-        "async": "^2.5.0",
-        "coffee-script": "1.8.0",
-        "ioredis": "~4.17.3",
-        "redis-sentinel": "0.1.1",
-        "underscore": "1.7.0"
-      },
-      "dependencies": {
-        "coffee-script": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
-          "integrity": "sha512-EvLTMcu9vR6G1yfnz75yrISvhq1eBPC+pZbQhHzTiC5vXgpYIrArxQc5tB+SYfBi3souVdSZ4AZzYxI72oLXUw==",
-          "requires": {
-            "mkdirp": "~0.3.5"
-          }
-        },
-        "underscore": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-          "integrity": "sha512-cp0oQQyZhUM1kpJDLdGO1jPZHgS/MpzoWYfe9+CM2h/QGDZlqwT2T3YGukuBdaNJ/CAPoeyAZRRHz8JFo176vA=="
-        }
       }
     },
     "regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "format:fix": "node_modules/.bin/prettier-eslint $PWD'/**/*.js' --write"
   },
   "dependencies": {
+    "@overleaf/o-error": "^3.1.0",
+    "@overleaf/redis-wrapper": "^2.0.0",
     "JSONStream": "^1.3.5",
     "async": "^2.6.3",
     "aws-sdk": "^2.643.0",
@@ -32,7 +34,6 @@
     "mongo-uri": "^0.1.2",
     "mongodb": "^3.6.0",
     "redis": "~0.10.1",
-    "redis-sharelatex": "^1.0.13",
     "request": "~2.88.2",
     "requestretry": "^4.1.0",
     "s3-streams": "^0.4.0",

--- a/test/acceptance/js/helpers/TrackChangesClient.js
+++ b/test/acceptance/js/helpers/TrackChangesClient.js
@@ -17,7 +17,9 @@ const async = require('async')
 const zlib = require('zlib')
 const request = require('request')
 const Settings = require('settings-sharelatex')
-const rclient = require('redis-sharelatex').createClient(Settings.redis.history) // Only works locally for now
+const rclient = require('@overleaf/redis-wrapper').createClient(
+  Settings.redis.history
+) // Only works locally for now
 const Keys = Settings.redis.history.key_schema
 const { db, ObjectId } = require('../../../../app/js/mongodb')
 

--- a/test/unit/js/LockManager/LockManagerTests.js
+++ b/test/unit/js/LockManager/LockManagerTests.js
@@ -31,7 +31,7 @@ describe('LockManager', function () {
     }
     this.LockManager = SandboxedModule.require(modulePath, {
       requires: {
-        'redis-sharelatex': {
+        '@overleaf/redis-wrapper': {
           createClient: () => {
             return (this.rclient = { auth: sinon.stub() })
           }

--- a/test/unit/js/RedisManager/RedisManagerTests.js
+++ b/test/unit/js/RedisManager/RedisManagerTests.js
@@ -22,7 +22,7 @@ describe('RedisManager', function () {
   beforeEach(function () {
     this.RedisManager = SandboxedModule.require(modulePath, {
       requires: {
-        'redis-sharelatex': {
+        '@overleaf/redis-wrapper': {
           createClient: () => {
             return (this.rclient = {
               auth: sinon.stub(),


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3650

- removed support for redis-sentinel
- redis-wrapper was rewritten in plain ES and promisified
  - mostly internal changes
  - health check supports `await` natively
  - `multi().exec()` supports `await` and unpacks the `ioredis` result
- package renamed as `@overleaf/redis-wrapper`
   - requires changed imports
- added `peerDependency` of `@overleaf/o-error@3.1.0`
   - requires an added/updated production dependency on o-error
- bring back support for redis-cluster

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3650

https://github.com/overleaf/redis-wrapper/pull/16

#### Potential Impact

High. The health check has been rewritten, so was the ioredis result unpacking.

#### Manual testing performed

- Health check: simulate redis failures (unavailable, corrupted read)
- I tested the services locally in dev-environment
   - dashboard
   - editor
   - edits
- I deployed from the PR branch into staging (all but analytics)
   - same as for local testing
   - dropbox sync tested in both directions
- The rewrite was upstreamed from my fork, and most of it was running since
   the end of August (ES/o-error since April) in my infra with a redis-cluster.