### PR TITLE
Upgrade build-scripts to 3.4.0

### DIFF
--- a/buildscript.txt
+++ b/buildscript.txt
@@ -5,4 +5,4 @@ track-changes
 --env-pass-through=
 --node-version=10.22.1
 --public-repo=True
---script-version=3.3.4
+--script-version=3.4.0

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -20,6 +20,7 @@ services:
     environment:
       ELASTIC_SEARCH_DSN: es:9200
       REDIS_HOST: redis
+      QUEUES_REDIS_HOST: redis
       MONGO_HOST: mongo
       POSTGRES_HOST: postgres
       AWS_S3_ENDPOINT: http://s3:9090
@@ -50,12 +51,22 @@ services:
     user: root
   redis:
     image: redis
+    healthcheck:
+      test: ping="$$(redis-cli ping)" && [ "$$ping" = 'PONG' ]
+      interval: 1s
+      retries: 20
 
   mongo:
     image: mongo:4.0
+    healthcheck:
+      test: "mongo --quiet localhost/test --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 1)'"
+      interval: 1s
+      retries: 20
   s3:
-    build:
-      context: test/acceptance/deps
-      dockerfile: Dockerfile.s3mock
+    image: adobe/s3mock
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files,bucket
+    healthcheck:
+      test: wget --quiet --output-document=/dev/null http://localhost:9090
+      interval: 1s
+      retries: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       ELASTIC_SEARCH_DSN: es:9200
       REDIS_HOST: redis
+      QUEUES_REDIS_HOST: redis
       MONGO_HOST: mongo
       POSTGRES_HOST: postgres
       AWS_S3_ENDPOINT: http://s3:9090
@@ -48,13 +49,23 @@ services:
 
   redis:
     image: redis
+    healthcheck:
+      test: ping=$$(redis-cli ping) && [ "$$ping" = 'PONG' ]
+      interval: 1s
+      retries: 20
 
   mongo:
     image: mongo:4.0
+    healthcheck:
+      test: "mongo --quiet localhost/test --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 1)'"
+      interval: 1s
+      retries: 20
 
   s3:
-    build:
-      context: test/acceptance/deps
-      dockerfile: Dockerfile.s3mock
+    image: adobe/s3mock
     environment:
       - initialBuckets=fake_user_files,fake_template_files,fake_public_files,bucket
+    healthcheck:
+      test: wget --quiet --output-document=/dev/null http://localhost:9090
+      interval: 1s
+      retries: 20


### PR DESCRIPTION
This version fixes docker-compose health checks for dependent services. See
https://github.com/overleaf/dev-environment/pull/409 for details.