### PR TITLE
[misc] add linting for missing explicit dependencies and fix any errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,10 @@
   "rules": {
     // Swap the no-unused-expressions rule with a more chai-friendly one
     "no-unused-expressions": 0,
-    "chai-friendly/no-unused-expressions": "error"
+    "chai-friendly/no-unused-expressions": "error",
+
+    // Do not allow importing of implicit dependencies.
+    "import/no-extraneous-dependencies": "error"
   },
   "overrides": [
     {
@@ -57,7 +60,13 @@
       "files": ["app/**/*.js", "app.js", "index.js"],
       "rules": {
         // don't allow console.log in backend code
-        "no-console": "error"
+        "no-console": "error",
+
+        // Do not allow importing of implicit dependencies.
+        "import/no-extraneous-dependencies": ["error", {
+          // Do not allow importing of devDependencies.
+          "devDependencies": false
+        }]
       }
     }
   ]

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -5,4 +5,4 @@ track-changes
 --env-pass-through=
 --node-version=12.21.0
 --public-repo=True
---script-version=3.7.0
+--script-version=3.8.0


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3851
Uses https://github.com/overleaf/dev-environment/pull/470

> This PR is adding linting rules for flagging imports from npm that are not properly specified in the package.json. Either they are missing at all and the `node_modules/` entry is there by chance via another dependency, or they are specified in the wrong section, e.g. using a `devDependency` in `app/js/`.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3851
Uses https://github.com/overleaf/dev-environment/pull/470

#### Potential Impact

Low.