### PR TITLE
Write zip file to disk before sending

### DIFF
--- a/app/js/HttpController.js
+++ b/app/js/HttpController.js
@@ -20,8 +20,6 @@ const RestoreManager = require('./RestoreManager')
 const ZipManager = require('./ZipManager')
 const logger = require('logger-sharelatex')
 const HealthChecker = require('./HealthChecker')
-const _ = require('underscore')
-const { pipeline } = require('stream')
 
 module.exports = HttpController = {
   flushDoc(req, res, next) {
@@ -208,11 +206,7 @@ module.exports = HttpController = {
   zipProject(req, res, next) {
     const { project_id } = req.params
     logger.log({ project_id }, 'exporting project history as zip file')
-    ZipManager.exportProject(project_id, function (err, outputStream) {
-      pipeline(outputStream, res, err => {
-        if (err) logger.error({ project_id, err }, 'zip pipeline error')
-      })
-    })
+    ZipManager.exportProject(project_id, res).then(next, next)
   },
 
   exportProject(req, res, next) {

--- a/app/js/PackManager.js
+++ b/app/js/PackManager.js
@@ -437,7 +437,7 @@ module.exports = PackManager = {
             )
             .toArray((err, packs) => {
               packs.forEach(pack => {
-                docIdSet.add(pack.doc_id)
+                docIdSet.add(pack.doc_id.toString())
               })
               return cb()
             })
@@ -447,7 +447,7 @@ module.exports = PackManager = {
             .find({ project_id: ObjectId(project_id) })
             .toArray((err, indexes) => {
               indexes.forEach(index => {
-                docIdSet.add(index._id)
+                docIdSet.add(index._id.toString())
               })
               return cb()
             })


### PR DESCRIPTION
The `HttpController.zipProject` endpoint will now wait for the zip archive to be written to disk before sending it, so that an appropriate error response can be sent instead if something goes wrong.

Promise rejections are now handled appropriately, so the response doesn't hang if there's an error.

`tempy` is added as a dependency, so it can handle creating the temporary file and cleaning it up at the end.